### PR TITLE
feat: configurable mirror country

### DIFF
--- a/00-preinstall.sh
+++ b/00-preinstall.sh
@@ -4,6 +4,11 @@
 set -e
 : "${DISK:?}" "${USERNAME:?}" "${PASSWORD:?}" "${HOSTNAME:?}" "${TIMEZONE:?}" "${KEYMAP:?}"
 
+if [[ -z "${MIRROR_COUNTRY:-}" ]]; then
+    read -rp "[?] Mirror country [Spain]: " MIRROR_COUNTRY
+    MIRROR_COUNTRY=${MIRROR_COUNTRY:-Spain}
+fi
+
 echo "[+] Configurando teclado..."
 loadkeys "$KEYMAP"
 
@@ -12,6 +17,6 @@ timedatectl set-ntp true
 
 echo "[+] Configurando mirrors con reflector..."
 pacman -Sy --noconfirm reflector
-reflector --country Spain --age 12 --protocol https --sort rate --save /etc/pacman.d/mirrorlist
+reflector --country "$MIRROR_COUNTRY" --age 12 --protocol https --sort rate --save /etc/pacman.d/mirrorlist
 
 echo "[✓] Preinstalación completada."

--- a/README.md
+++ b/README.md
@@ -8,8 +8,14 @@ cd mateOS
 # Opción A: Sin interacción (define variables)
 DISK=/dev/nvme0n1 HOSTNAME=mateos USERNAME=rubrick PASSWORD='tuPass' ROOT_PW='root' \
 TIMEZONE=Europe/Madrid KEYMAP=es LOCALE=en_US.UTF-8 LOCALE2=es_ES.UTF-8 \
-BTRFS_COMPRESSION=zstd SWAPFILE_SIZE=8G \
+BTRFS_COMPRESSION=zstd SWAPFILE_SIZE=8G MIRROR_COUNTRY=Spain \
 ./install.sh
 
 # Opción B: Semi-guiado (usa gum si está disponible)
 ./install.sh
+```
+
+### Variables de entorno
+
+- `MIRROR_COUNTRY`: País usado por reflector para seleccionar mirrors. Valor por defecto: `Spain`.
+  Si no se define, el script preguntará durante la ejecución.


### PR DESCRIPTION
## Summary
- allow setting MIRROR_COUNTRY via env var or prompt in pre-install script
- document MIRROR_COUNTRY env var in README with default

## Testing
- `bash -n 00-preinstall.sh`
- `shellcheck 00-preinstall.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a13dae2df08332a8ec22b7c454aa35