### PR TITLE
feat: allow non-interactive install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # mateOS Arch Installer (Hyprland Edition)
 
 ## Uso rápido
+Las variables de entorno `DISK`, `HOSTNAME`, `USERNAME`, `PASS` y `TIMEZONE` permiten
+ejecutar el instalador sin preguntas.
 ```bash
 pacman -Sy --noconfirm git
 git clone https://github.com/danteRub/mateOS
 cd mateOS
 # Opción A: Sin interacción (define variables)
-DISK=/dev/nvme0n1 HOSTNAME=mateos USERNAME=rubrick PASSWORD='tuPass' ROOT_PW='root' \
-TIMEZONE=Europe/Madrid KEYMAP=es LOCALE=en_US.UTF-8 LOCALE2=es_ES.UTF-8 \
-BTRFS_COMPRESSION=zstd SWAPFILE_SIZE=8G \
+DISK=/dev/nvme0n1 HOSTNAME=mateos USERNAME=rubrick PASS='tuPass' TIMEZONE=Europe/Madrid \
 ./install.sh
 
-# Opción B: Semi-guiado (usa gum si está disponible)
+# Opción B: Interactivo
 ./install.sh
+```

--- a/install.sh
+++ b/install.sh
@@ -28,16 +28,26 @@ ping -c1 -W2 archlinux.org >/dev/null 2>&1 || step "Aviso: no pude hacer ping; s
 
 ### Preguntas mínimas
 echo
-read -rp "Disco destino (ej: /dev/nvme0n1 o /dev/sda): " DISK
+if [ -z "${DISK:-}" ]; then
+  read -rp "Disco destino (ej: /dev/nvme0n1 o /dev/sda): " DISK
+fi
 [ -b "$DISK" ] || fatal "Disco inexistente: $DISK"
 
-read -rp "Hostname (ej: mateos): " HOSTNAME
-read -rp "Usuario (ej: rubrick): " USERNAME
-read -rsp "Contraseña para $USERNAME: " PASS; echo
-read -rsp "Confirma contraseña: " PASS2; echo
-[ "$PASS" = "$PASS2" ] || fatal "Las contraseñas no coinciden."
+if [ -z "${HOSTNAME:-}" ]; then
+  read -rp "Hostname (ej: mateos): " HOSTNAME
+fi
+if [ -z "${USERNAME:-}" ]; then
+  read -rp "Usuario (ej: rubrick): " USERNAME
+fi
+if [ -z "${PASS:-}" ]; then
+  read -rsp "Contraseña para $USERNAME: " PASS; echo
+  read -rsp "Confirma contraseña: " PASS2; echo
+  [ "$PASS" = "$PASS2" ] || fatal "Las contraseñas no coinciden."
+fi
 
-read -rp "Zona horaria [Europe/Madrid]: " TIMEZONE
+if [ -z "${TIMEZONE:-}" ]; then
+  read -rp "Zona horaria [Europe/Madrid]: " TIMEZONE
+fi
 TIMEZONE=${TIMEZONE:-Europe/Madrid}
 
 ### Detección entorno (UEFI/BIOS)


### PR DESCRIPTION
## Summary
- skip interactive prompts when DISK, HOSTNAME, USERNAME, PASS or TIMEZONE are preset
- document environment variables for unattended install

## Testing
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a13dc9ea248332ac7d543ae7e99ed8