### PR TITLE
docs: remove outdated btrfs instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # mateOS Arch Installer (Hyprland Edition)
 
 ## Uso rápido
+
 ```bash
 pacman -Sy --noconfirm git
 git clone https://github.com/danteRub/mateOS
 cd mateOS
 # Opción A: Sin interacción (define variables)
-DISK=/dev/nvme0n1 HOSTNAME=mateos USERNAME=rubrick PASSWORD='tuPass' ROOT_PW='root' \
-TIMEZONE=Europe/Madrid KEYMAP=es LOCALE=en_US.UTF-8 LOCALE2=es_ES.UTF-8 \
-BTRFS_COMPRESSION=zstd SWAPFILE_SIZE=8G \
+DISK=/dev/nvme0n1 HOSTNAME=mateos USERNAME=rubrick PASSWORD='tuPass' \
+ROOT_PW='root' TIMEZONE=Europe/Madrid KEYMAP=es \
+LOCALE=en_US.UTF-8 LOCALE2=es_ES.UTF-8 \
 ./install.sh
 
 # Opción B: Semi-guiado (usa gum si está disponible)
 ./install.sh
+```
+
+Este instalador usa una partición ext4 para la raíz y habilita
+swap mediante zram.
+El soporte para Btrfs y swapfile aún no está implementado.


### PR DESCRIPTION
## Summary
- clarify quick start usage by dropping unused Btrfs and swap variables
- document that installer uses ext4 with zram swap and lacks Btrfs/swapfile support

## Testing
- `npx --yes markdownlint-cli README.md`
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a13db4272c8332bffb1211f271c0a7